### PR TITLE
Make it only show with status bar clock

### DIFF
--- a/src/com/hamzah/hijriclock/Main.java
+++ b/src/com/hamzah/hijriclock/Main.java
@@ -3,6 +3,7 @@ package com.hamzah.hijriclock;
 import static de.robv.android.xposed.XposedHelpers.findAndHookMethod;
 import android.os.Build;
 import android.widget.TextView;
+import android.view.View;
 import de.robv.android.xposed.IXposedHookLoadPackage;
 import de.robv.android.xposed.XC_MethodHook;
 import de.robv.android.xposed.XSharedPreferences;


### PR DESCRIPTION
If you looked at my comment on the last commit, In the screen shot the date is shown both with the clock and date. Now it will show in the status bar with the clock, and with the date only in the notification panel.

Also add checking if the date changed because this is how it looks with "Show before clock"
![screenshot_2014-07-05-23-35-05](https://cloud.githubusercontent.com/assets/6565963/3487510/ec33b86e-0483-11e4-8478-83572cb09acc.png)
and it will continue until the original date disappears.

Can you check if the Id (2131230770) I used is the same for you ? 
Edit:Use this to log the IDs
String id=""+parent.getId();
Log.d("HijriClock", id);
